### PR TITLE
Delete unused .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "m4"]
-    path = m4
-    url = https://gitlab.freedesktop.org/xorg/util/xcb-util-m4.git


### PR DESCRIPTION
- https://github.com/SimulaVR/Simula/pull/208

# Why did I created this PR

This repository is used in `/submodules/wlroots/libxcb-errors` where it is `SimulaVR/Simula` repo. I have been creating Nix flakes in `SimulaVR/Simula` repo, but Nix flakes' submodule fetching is failed because `/.gitmodules` records nonexistece submodule, `m4`, deleted by 6b011619a6682ca53ec33a26ad5da97531920545 .

# Changes

- Simply Delete `/.gitmodules`